### PR TITLE
Modify OverpassAPI query to return only first matching area

### DIFF
--- a/streetviews_grabber/osm.py
+++ b/streetviews_grabber/osm.py
@@ -6,7 +6,7 @@ import overpy
 
 def get_osm_data(city, alternative_server):
     query = f"""
-    area[name="{city}"];
+    area[name="{city}"][1];
     (way["highway"](area); >;);
     out skel;
     """


### PR DESCRIPTION
The previous query was returning all matching areas for the `{city}` parameter, which could cause problems if the city name was used in multiple locations. This commit modifies the query to use the `[1]` operator in the `area` parameter, which ensures that only the first matching area is returned. This improves the reliability and accuracy of the query results.

Issue: #8